### PR TITLE
[CLOUD-737-attach-functionality]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'simplecov', :require => false
 
 gem 'pry-nav'
 gem 'pry-rescue'
+gem 'pry'
 
 # optional dependency for more accurate timezone conversion
 gem 'tzinfo', '1.2.5'

--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -49,6 +49,7 @@ module NetSuite
 
   module Actions
     autoload :Add,              'netsuite/actions/add'
+    autoload :Attach,           'netsuite/actions/attach'
     autoload :Delete,           'netsuite/actions/delete'
     autoload :DeleteList,       'netsuite/actions/delete_list'
     autoload :Get,              'netsuite/actions/get'
@@ -74,6 +75,7 @@ module NetSuite
     autoload :Account,                          'netsuite/records/account'
     autoload :AccountingPeriod,                 'netsuite/records/accounting_period'
     autoload :Address,                          'netsuite/records/address'
+    autoload :AttachBasicReference,             'netsuite/records/attach_basic_reference'
     autoload :BaseRefList,                      'netsuite/records/base_ref_list'
     autoload :BillAddress,                      'netsuite/records/bill_address'
     autoload :BillingSchedule,                  'netsuite/records/billing_schedule'

--- a/lib/netsuite/actions/add.rb
+++ b/lib/netsuite/actions/add.rb
@@ -73,7 +73,6 @@ module NetSuite
       module Support
         def add(credentials={})
           response = NetSuite::Actions::Add.call([self], credentials)
-
           @errors = response.errors
 
           if response.success?

--- a/lib/netsuite/actions/attach.rb
+++ b/lib/netsuite/actions/attach.rb
@@ -1,0 +1,87 @@
+module NetSuite
+  module Actions
+    class Attach
+      include Support::Requests
+
+      attr_reader :response_hash
+
+      def initialize(object=nil)
+        @object = object
+      end
+
+      private
+
+      def request(credentials={})
+        NetSuite::Configuration.connection({}, credentials).call(:attach, :message => request_body)
+      end
+      
+      #please note, reference is spelled referece and is documented that way in NetSuite's documentation
+      # <soap:Body>
+      #   <platformMsgs:attach>
+      #     <platformMsgs:attachReferece xsi:type="platformCore:AttachBasicReference">
+      #       <platformCore:attachTo internalId="443" type="vendorBill" xsi:type="platformCore:RecordRef"/>
+      #       <platformCore:attachedRecord type="file" internalId="353" xsi:type="platformCore:RecordRef"/>
+      #     </platformMsgs:attachReferece>
+      #   </platformMsgs:attach>
+      # </soap:Body>
+      
+      def request_body
+        hash = {
+          'platformMsgs:attachReferece' => {
+            :content! => @object.to_record,
+            '@xsi:type' => @object.record_type
+          }
+        }
+        #not crazy about this solution but not sure how else to get the 'xsi:type' var in the hash
+        hash["platformMsgs:attachReferece"][:content!][:attributes!]["platformCore:attachTo"]["xsi:type"] = "platformCore:RecordRef"
+        hash["platformMsgs:attachReferece"][:content!][:attributes!]["platformCore:attachedRecord"]["xsi:type"] = "platformCore:RecordRef"
+
+        hash
+      end
+
+      def success?
+        @success ||= response_hash[:status][:@is_success] == 'true'
+      end
+
+      def response_body
+        @response_body ||= response_hash[:base_ref]
+      end
+
+      def response_errors
+        if response_hash[:status] && response_hash[:status][:status_detail]
+          @response_errors ||= errors
+        end
+      end
+
+      def response_hash
+        @response_hash ||= @response.to_hash[:attach_response][:write_response]
+      end
+
+      def errors
+        error_obj = response_hash[:status][:status_detail]
+        error_obj = [error_obj] if error_obj.class == Hash
+        error_obj.map do |error|
+          NetSuite::Error.new(error)
+        end
+      end
+
+
+      module Support
+        def attach(credentials={})
+          response = NetSuite::Actions::Attach.call([self], credentials)
+
+          @errors = response.errors
+
+          if response.success?
+            @internal_id = response.body[:@internal_id]
+            true
+          else
+            false
+          end
+        end
+      end
+    
+    
+    end
+  end
+end

--- a/lib/netsuite/records/attach_basic_reference.rb
+++ b/lib/netsuite/records/attach_basic_reference.rb
@@ -1,0 +1,20 @@
+module NetSuite
+  module Records
+    class AttachBasicReference
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Support::Actions
+      include Namespaces::PlatformCore
+
+      actions :attach
+
+      record_refs :attach_to, :attached_record
+
+      def initialize(attributes = {})
+        initialize_from_attributes_hash(attributes)
+      end
+
+    end
+  end
+end

--- a/lib/netsuite/support/actions.rb
+++ b/lib/netsuite/support/actions.rb
@@ -46,6 +46,8 @@ module NetSuite
             self.send(:include, NetSuite::Actions::UpdateList::Support)
           when :initialize
             self.send(:include, NetSuite::Actions::Initialize::Support)
+          when :attach
+            self.send(:include, NetSuite::Actions::Attach::Support)
           else
             raise "Unknown action: #{name.inspect}"
           end

--- a/spec/netsuite/actions/attach_spec.rb
+++ b/spec/netsuite/actions/attach_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe NetSuite::Actions::Attach do
+  before(:all) { savon.mock! }
+  after(:all) { savon.unmock! }
+
+  context "AttachBasicReference" do
+    let(:attach_basic_reference) do
+      NetSuite::Records::AttachBasicReference.new(:attach_to => {internal_id: "11111", type: "VendorBill"}, :attached_record => {internal_id: "22222", type: "File"})
+    end
+
+    before do 
+      savon.expects(:attach).with(:message => {
+        'platformMsgs:attachReferece' => {
+          :content! => {
+            :attributes! => {
+              "platformCore:attachTo" => {
+                "internalId"=>"11111", 
+                "type"=>"vendorBill",  "xsi:type"=>"platformCore:RecordRef"
+              },
+              "platformCore:attachedRecord"=> {
+                "internalId"=>"22222", 
+                "type"=>"file", 
+                "xsi:type"=>"platformCore:RecordRef"
+              }
+            },
+            "platformCore:attachTo"=>{},
+            "platformCore:attachedRecord"=>{}
+          },
+          "@xsi:type"=>"platformCore:AttachBasicReference"
+          }
+        }).returns(File.read('spec/support/fixtures/attach/attach_file_to_bill.xml'))  
+    end
+
+
+    it "makes a valid request to the NetSuite API" do 
+      NetSuite::Actions::Attach.call([attach_basic_reference])
+    end
+
+    it "returns a valid Response object" do 
+      response = NetSuite::Actions::Attach.call([attach_basic_reference])
+      expect(response).to be_kind_of(NetSuite::Response)
+      expect(response).to be_success
+    end
+
+    context "when not successful" do
+      before do 
+        savon.expects(:attach).with(:message => {
+          'platformMsgs:attachReferece' => {
+            :content! => {
+              :attributes! => {
+                "platformCore:attachTo" => {
+                  "internalId"=>"11111", 
+                  "type"=>"vendorBill",  "xsi:type"=>"platformCore:RecordRef"
+                },
+                "platformCore:attachedRecord"=> {
+                  "internalId"=>"22222", 
+                  "type"=>"file", 
+                  "xsi:type"=>"platformCore:RecordRef"
+                }
+              },
+              "platformCore:attachTo"=>{},
+              "platformCore:attachedRecord"=>{}
+            },
+            "@xsi:type"=>"platformCore:AttachBasicReference"
+            }
+          }).returns(File.read('spec/support/fixtures/attach/attach_file_to_bill_error.xml'))  
+      end
+
+      it 'provides an error method on the object with details about the error' do 
+        #i'm not sure why the only way to get the errors is to attach twice 
+        attach_basic_reference.attach
+        attach_basic_reference.attach
+        error = attach_basic_reference.errors.first
+        expect(error).to be_kind_of(NetSuite::Error)
+        expect(error.type).to eq('ERROR')
+        expect(error.code).to eq('USER_ERROR')
+        expect(error.message).to eq('Invalid Attachment record combination')
+      end
+    end
+  end
+end

--- a/spec/netsuite/records/attach_basic_reference_spec.rb
+++ b/spec/netsuite/records/attach_basic_reference_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe NetSuite::Records::AttachBasicReference do
+  let(:attach_basic_reference) { NetSuite::Records::AttachBasicReference.new }
+
+  it "has all the right record refs" do
+    [:attach_to, :attached_record].each do |record_ref|
+      expect(attach_basic_reference).to have_record_ref(record_ref)
+    end
+  end
+
+  describe '#attach' do
+    let(:test_data) { {:attach_to => {internal_id: "11111", type: "VendorBill"}, :attached_record => {internal_id: "22222", type: "File"} } }
+    context 'when the response is successful' do 
+      let(:response) { NetSuite::Response.new(:success => true, :body => { :internal_id => '11111' }) }
+
+      it "returns true" do
+        attach_basic_reference = NetSuite::Records::AttachBasicReference.new(test_data)
+
+        expect(NetSuite::Actions::Attach).to receive(:call).with([attach_basic_reference], {}).and_return(response)
+        expect(attach_basic_reference.attach).to be_truthy
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:response) { NetSuite::Response.new(:success => false, :body => {}) }
+
+      it 'returns false' do
+        attach_basic_reference = NetSuite::Records::AttachBasicReference.new(test_data)
+
+        expect(NetSuite::Actions::Attach).to receive(:call).with([attach_basic_reference], {}).and_return(response)
+        expect(attach_basic_reference.attach).to be_falsey
+      end
+    end
+
+  end
+
+end

--- a/spec/support/fixtures/attach/attach_file_to_bill.xml
+++ b/spec/support/fixtures/attach/attach_file_to_bill.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<soapenv:Header>
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2011_2.platform.webservices.netsuite.com">
+      <platformMsgs:nsId>WEBSERVICES_3392464_1220201115821392011296470399_67055c545d0</platformMsgs:nsId>
+    </platformMsgs:documentInfo>
+  </soapenv:Header>
+  <soapenv:Body>
+   <attachResponse xmlns="urn:messages_2016_2.platform.webservices.netsuite.com">
+      <writeResponse>
+        <platformCore:status xmlns:platformCore="urn:core_2016_2.platform.webservices.netsuite.com" isSuccess="true"/>
+        <baseRef xmlns:platformCore="urn:core_2016_2.platform.webservices.netsuite.com" internalId="11111" type="vendorBill" xsi:type="platformCore:RecordRef"/>
+      </writeResponse>
+    </attachResponse>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/support/fixtures/attach/attach_file_to_bill_error.xml
+++ b/spec/support/fixtures/attach/attach_file_to_bill_error.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header>
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2016_2.platform.webservices.netsuite.com">
+      <platformMsgs:nsId>WEBSERVICES_5102954_SB1_110820191277209614860972177_6400640b</platformMsgs:nsId>
+    </platformMsgs:documentInfo>
+  </soapenv:Header>
+  <soapenv:Body>
+    <attachResponse xmlns="urn:messages_2016_2.platform.webservices.netsuite.com">
+      <writeResponse>
+        <platformCore:status xmlns:platformCore="urn:core_2016_2.platform.webservices.netsuite.com" isSuccess="false">
+          <platformCore:statusDetail type="ERROR">
+            <platformCore:code>USER_ERROR</platformCore:code>
+            <platformCore:message>Invalid Attachment record combination</platformCore:message>
+          </platformCore:statusDetail>
+        </platformCore:status>
+      </writeResponse>
+    </attachResponse>
+  </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
WHY: previously could not utilize soap action attach
This adds the attach basic reference functionality into the gem