### PR TITLE
[hotfix-CLOUD-737]

### DIFF
--- a/lib/netsuite/actions/add.rb
+++ b/lib/netsuite/actions/add.rb
@@ -74,10 +74,15 @@ module NetSuite
         def add(credentials={})
           response = NetSuite::Actions::Add.call([self], credentials)
           @errors = response.errors
-
+          
           if response.success?
-            @internal_id = response.body[:@internal_id]
-            true
+            if response.body.class == Nori::StringIOFile
+              @original_filename = response.body.original_filename
+              true
+            else
+              @internal_id = response.body[:@internal_id]
+              true
+            end
           else
             false
           end


### PR DESCRIPTION
Why:

When adding a file from a workflow, even though it will sometimes be 'succuessful' it was still returning a 500 to the platform
This change addresses the need by:

made an update to the gem to return true/200 if a file is created and to return the file name if it is successfully created so we can query file by that attribute to create attachment
Ticket

[CLOUD-737]