### PR TITLE
[CLD-659-sales-order-lines]

### DIFF
--- a/lib/netsuite/records/sales_order_item.rb
+++ b/lib/netsuite/records/sales_order_item.rb
@@ -21,7 +21,7 @@ module NetSuite
 
       field :custom_field_list, CustomFieldList
 
-      record_refs :department, :item, :job, :klass, :location, :price, :rev_rec_schedule, :tax_code, :units
+      record_refs :department, :item, :job, :klass, :location, :price, :rev_rec_schedule, :tax_code, :units, :inventory_location, :inventory_subsidiary
 
       def initialize(attributes_or_record = {})
         case attributes_or_record


### PR DESCRIPTION
*Why:

Inventory subsidiary and inventory location were not present fields on the sales order line item

*This change addresses the need by:

Added those two fields