### PR TITLE
[CLD-669-vendorcredit-record-refs]

### DIFF
--- a/lib/netsuite/records/vendor_credit.rb
+++ b/lib/netsuite/records/vendor_credit.rb
@@ -15,17 +15,8 @@ module NetSuite
              :currency_name, :tran_date,  :exchange_rate,
              :memo
 
-      field :custom_form,        RecordRef
-      field :account,            RecordRef
-      field :bill_address_list,  RecordRef
-      field :created_from,       RecordRef
-      field :entity,             RecordRef
-      field :currency,           RecordRef
-      field :posting_period,     RecordRef
-      field :department,         RecordRef
-      field :klass,              RecordRef
-      field :location,           RecordRef
-      field :subsidiary,         RecordRef
+      record_refs :custom_form, :account, :bill_address_list, :created_from, :entity, :currency, :post_period, :department, :klass, :location, :subsidiary
+
       field :billing_address,    Address
       field :expense_list,       VendorCreditExpenseList
       field :item_list,          VendorCreditItemList

--- a/lib/netsuite/records/vendor_credit_expense.rb
+++ b/lib/netsuite/records/vendor_credit_expense.rb
@@ -2,6 +2,7 @@ module NetSuite
   module Records
     class VendorCreditExpense
       include Support::Fields
+      include Support::RecordRefs
       include Support::Records
       include Namespaces::TranPurch
 
@@ -12,15 +13,9 @@ module NetSuite
              :amortization_end_date,
              :amortization_residual
 
-      field :category,            RecordRef
-      field :taxCode,             RecordRef
-      field :account,             RecordRef
-      field :department,          RecordRef
-      field :klass,               RecordRef
-      field :amortizationSched,   RecordRef
-      field :location,            RecordRef
-      field :customer,            RecordRef
       field :custom_field_list,   CustomFieldList
+
+      record_refs :account, :category, :customer, :department, :item, :location, :units, :tax_code
 
       def initialize(attributes = {})
         initialize_from_attributes_hash(attributes)

--- a/lib/netsuite/records/vendor_credit_item.rb
+++ b/lib/netsuite/records/vendor_credit_item.rb
@@ -2,6 +2,7 @@ module NetSuite
   module Records
     class VendorCreditItem
       include Support::Fields
+      include Support::RecordRefs
       include Support::Records
       include Namespaces::TranPurch
 
@@ -14,16 +15,12 @@ module NetSuite
              :amortization_end_date,
              :amortization_residual
 
-       field :item,                RecordRef
-       field :units,               RecordRef
-       field :department,          RecordRef
-       field :customer,            RecordRef
-       field :location,            RecordRef
-       field :tax_code,            RecordRef
-       field :serial_numbers_list, RecordRefList
-       field :inventory_detail,    InventoryDetail
-       field :custom_field_list,   CustomFieldList
-       field :options,             CustomFieldList
+      field :serial_numbers_list, RecordRefList
+      field :inventory_detail,    InventoryDetail
+      field :custom_field_list,   CustomFieldList
+      field :options,             CustomFieldList
+
+      record_refs :item, :units, :department, :customer, :location, :tax_code
 
       def initialize(attributes = {})
         initialize_from_attributes_hash(attributes)


### PR DESCRIPTION
*Why:

The vendor credit object in the gem previously had record reference fields defined differently than the majority of the other objects in the gem.  Because of this, when we call '.record_refs' in the connector, it was erroring

*This addresses the change by:

Adding in the record ref support and redefined how the record reference fields are defined.

[CLD-669]