### PR TITLE
[CLD-725-expenses-on-purchaseorders]

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -240,6 +240,8 @@ module NetSuite
     autoload :PromotionsList,                   'netsuite/records/promotions_list'
     autoload :Promotions,                       'netsuite/records/promotions'
     autoload :PurchaseOrder,                    'netsuite/records/purchase_order'
+    autoload :PurchaseOrderExpenseList,         'netsuite/records/purchase_order_expense_list'
+    autoload :PurchaseOrderExpense,             'netsuite/records/purchase_order_expense'
     autoload :PurchaseOrderItemList,            'netsuite/records/purchase_order_item_list'
     autoload :PurchaseOrderItem,                'netsuite/records/purchase_order_item'
     autoload :Roles,                            'netsuite/records/roles'

--- a/lib/netsuite/records/purchase_order.rb
+++ b/lib/netsuite/records/purchase_order.rb
@@ -20,6 +20,7 @@ module NetSuite
       field :shipping_address,  Address
       field :custom_field_list, CustomFieldList
       field :item_list,         PurchaseOrderItemList
+      field :expense_list,      PurchaseOrderExpenseList
 
       # TODO custom lists
       # :ship_address_list

--- a/lib/netsuite/records/purchase_order_expense.rb
+++ b/lib/netsuite/records/purchase_order_expense.rb
@@ -1,0 +1,37 @@
+module NetSuite
+  module Records
+    class PurchaseOrderExpense
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Namespaces::TranPurch
+
+      fields :amount, :gross_amt, :is_billable, :is_closed, :line, :memo, :tax1_amt, :tax_amount, :tax_details_reference, :tax_rate1, :tax_rate2
+
+      field :custom_field_list, CustomFieldList
+
+      record_refs :account, :category, :klass, :created_from, :customer, :department, :linked_order_list, :location, :tax_code
+
+      def initialize(attributes_or_record = {})
+        case attributes_or_record
+        when Hash
+          initialize_from_attributes_hash(attributes_or_record)
+        when self.class
+          initialize_from_record(attributes_or_record)
+        end
+      end
+
+      def initialize_from_record(record)
+        self.attributes = record.send(:attributes)
+      end
+
+      def to_record
+        rec = super
+        if rec["#{record_namespace}:customFieldList"]
+          rec["#{record_namespace}:customFieldList!"] = rec.delete("#{record_namespace}:customFieldList")
+        end
+        rec
+      end
+    end
+  end
+end

--- a/lib/netsuite/records/purchase_order_expense_list.rb
+++ b/lib/netsuite/records/purchase_order_expense_list.rb
@@ -1,0 +1,11 @@
+module NetSuite
+  module Records
+    class PurchaseOrderExpenseList < Support::Sublist
+      include Namespaces::TranPurch
+
+      sublist :expense, PurchaseOrderExpense
+
+      alias :expenses :expense
+    end
+  end
+end


### PR DESCRIPTION
Why:

*The purchase order expenses were not supported within the gem, so they were being returned in the soap response but not in the json response returned by the gem.  With this object missing, it would not have allowed posting a purchase order with an expense list either.

This change addresses the need by:

*Added the purchase order expense list record and the purchase order expense record

Ticket

* [CLD-725]