### PR TITLE
[CLD-737-item-receipt-expenses]

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -200,6 +200,8 @@ module NetSuite
     autoload :ItemMember,                       'netsuite/records/item_member'
     autoload :ItemMemberList,                   'netsuite/records/item_member_list'
     autoload :ItemReceipt,                      'netsuite/records/item_receipt'
+    autoload :ItemReceiptExpenseList,           'netsuite/records/item_receipt_expense_list'
+    autoload :ItemReceiptExpense,               'netsuite/records/item_receipt_expense'
     autoload :ItemReceiptItemList,              'netsuite/records/item_receipt_item_list'
     autoload :ItemReceiptItem,                  'netsuite/records/item_receipt_item'
     autoload :ItemVendor,                       'netsuite/records/item_vendor'

--- a/lib/netsuite/records/item_receipt.rb
+++ b/lib/netsuite/records/item_receipt.rb
@@ -22,6 +22,7 @@ module NetSuite
       # :landed_costs_list
 
       field :item_list, ItemReceiptItemList
+      field :expense_list, ItemReceiptExpenseList
       field :custom_field_list, CustomFieldList
 
       attr_reader :internal_id

--- a/lib/netsuite/records/item_receipt_expense.rb
+++ b/lib/netsuite/records/item_receipt_expense.rb
@@ -1,0 +1,36 @@
+module NetSuite
+  module Records
+    class ItemReceiptExpense
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Namespaces::TranPurch
+
+      fields :account, :amount, :line, :mark_received, :memo, :order_line
+
+      field :options, CustomFieldList
+      field :custom_field_list, CustomFieldList
+
+      def initialize(attributes_or_record = {})
+        case attributes_or_record
+        when Hash
+          initialize_from_attributes_hash(attributes_or_record)
+        when self.class
+          initialize_from_record(attributes_or_record)
+        end
+      end
+
+      def initialize_from_record(record)
+        self.attributes = record.send(:attributes)
+      end
+
+      def to_record
+        rec = super
+        if rec["#{record_namespace}:customFieldList"]
+          rec["#{record_namespace}:customFieldList!"] = rec.delete("#{record_namespace}:customFieldList")
+        end
+        rec
+      end
+    end
+  end
+end

--- a/lib/netsuite/records/item_receipt_expense_list.rb
+++ b/lib/netsuite/records/item_receipt_expense_list.rb
@@ -1,0 +1,11 @@
+module NetSuite
+  module Records
+    class ItemReceiptExpenseList < Support::Sublist
+      include Namespaces::TranPurch
+
+      sublist :expense, ItemReceiptExpense
+
+      alias :expenses :expense
+    end
+  end
+end


### PR DESCRIPTION
Why:

*There was not support for expense lines to show up on item receipts in Netsuite

This change addresses the need by:

*added in the item receipt expense list and item receipt expense models to the gem

Ticket

* [CLD-737]