### PR TITLE
[CLD-878 Update config for versions]

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -27,6 +27,7 @@ module NetSuite
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
       }.update(params))
+      client.wsdl.endpoint = client.wsdl.endpoint.to_s.sub('//webservices.netsuite.com/', "//#{wsdl_domain}/")
       cache_wsdl(client)
       return client
     end


### PR DESCRIPTION
*Why:
Versions 2019 and later of Netsuite were not working
 
*How:
Versions 2019_1 and later require you to set the wsdl endpoint on the savon client so updated that in the configuration file.