### PR TITLE
[CLD-917-vendor-credit-klass]

### DIFF
--- a/lib/netsuite/records/vendor_credit_expense.rb
+++ b/lib/netsuite/records/vendor_credit_expense.rb
@@ -15,10 +15,27 @@ module NetSuite
 
       field :custom_field_list,   CustomFieldList
 
-      record_refs :account, :category, :customer, :department, :item, :location, :units, :tax_code
+      record_refs :account, :category, :customer, :department, :item, :location, :units, :tax_code,  :klass
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
+      def initialize(attributes_or_record = {})
+        case attributes_or_record
+        when Hash
+          initialize_from_attributes_hash(attributes_or_record)
+        when self.class
+          initialize_from_record(attributes_or_record)
+        end
+      end
+
+      def initialize_from_record(record)
+        self.attributes = record.send(:attributes)
+      end
+
+      def to_record
+        rec = super
+        if rec["#{record_namespace}:customFieldList"]
+          rec["#{record_namespace}:customFieldList!"] = rec.delete("#{record_namespace}:customFieldList")
+        end
+        rec
       end
 
     end

--- a/lib/netsuite/records/vendor_credit_item.rb
+++ b/lib/netsuite/records/vendor_credit_item.rb
@@ -20,10 +20,27 @@ module NetSuite
       field :custom_field_list,   CustomFieldList
       field :options,             CustomFieldList
 
-      record_refs :item, :units, :department, :customer, :location, :tax_code
+      record_refs :item, :units, :department, :customer, :location, :tax_code, :klass
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
+      def initialize(attributes_or_record = {})
+        case attributes_or_record
+        when Hash
+          initialize_from_attributes_hash(attributes_or_record)
+        when self.class
+          initialize_from_record(attributes_or_record)
+        end
+      end
+
+      def initialize_from_record(record)
+        self.attributes = record.send(:attributes)
+      end
+
+      def to_record
+        rec = super
+        if rec["#{record_namespace}:customFieldList"]
+          rec["#{record_namespace}:customFieldList!"] = rec.delete("#{record_namespace}:customFieldList")
+        end
+        rec
       end
 
     end


### PR DESCRIPTION
*Why:
  Earlier versions of netsuite did not have the field class on the vendor credit expense line level or the vendor credit item line level

*This addresses the need by:
  Added the class field to both the vendor credit expense record class and the vendor credit item record class.  Added the methods to those classes required for setting the record references appropriately

[CLD-917]