### PR TITLE
[CLD-1157-expense-accounts-added]

### DIFF
--- a/lib/netsuite/records/gift_certificate_item.rb
+++ b/lib/netsuite/records/gift_certificate_item.rb
@@ -64,7 +64,7 @@ module NetSuite
       field :custom_field_list, CustomFieldList
 
       record_refs :klass, :custom_form, :department, :income_account,
-                  :issue_product, :location, :parent, :sales_tax_code, :tax_schedule
+                  :issue_product, :liability_account, :location, :parent, :sales_tax_code, :tax_schedule
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/lot_numbered_assembly_item.rb
+++ b/lib/netsuite/records/lot_numbered_assembly_item.rb
@@ -34,7 +34,7 @@ module NetSuite
 
       record_refs :alternate_demand_source_item, :asset_account, :bill_exch_rate_variance_acct, :bill_price_variance_acct,
         :bill_qty_variance_acct, :billing_schedule, :cogs_account, :cost_category, :custom_form, :deferred_revenue_account,
-        :demand_source, :department, :expense_account, :gain_loss_account, :income_account, :issue_product, :klass, :location,
+        :demand_source, :department, :dropship_expense_account, :gain_loss_account, :income_account, :issue_product, :klass, :location,
         :parent, :preferred_location, :pricing_group, :purchase_price_variance_acct, :purchase_tax_code, :purchase_unit,
         :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :soft_descriptor,
         :stock_unit, :store_display_image, :store_display_thumbnail, :store_item_template, :supply_lot_sizing_method,

--- a/lib/netsuite/records/non_inventory_purchase_item.rb
+++ b/lib/netsuite/records/non_inventory_purchase_item.rb
@@ -25,7 +25,7 @@ module NetSuite
         :translations_list, :upc_code, :url_component, :use_marginal_rates, :vsoe_deferral, :vsoe_delivered,
         :vsoe_permit_discount, :vsoe_price, :weight, :weight_unit, :weight_units
 
-      record_refs :billing_schedule, :cost_category, :custom_form, :deferred_revenue_account, :department, :income_account,
+      record_refs :billing_schedule, :cost_category, :custom_form, :deferred_revenue_account, :department, :expense_account, :income_account,
         :issue_product, :item_options_list, :klass, :location, :parent, :pricing_group, :purchase_tax_code,
         :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :store_display_image,
         :store_display_thumbnail, :store_item_template, :tax_schedule, :units_type

--- a/lib/netsuite/records/non_inventory_resale_item.rb
+++ b/lib/netsuite/records/non_inventory_resale_item.rb
@@ -25,7 +25,7 @@ module NetSuite
         :translations_list, :upc_code, :url_component, :use_marginal_rates, :vsoe_deferral, :vsoe_delivered,
         :vsoe_permit_discount, :vsoe_price, :weight, :weight_unit, :weight_units
 
-      record_refs :billing_schedule, :cost_category, :custom_form, :deferred_revenue_account, :department, :income_account,
+      record_refs :billing_schedule, :cost_category, :custom_form, :deferred_revenue_account, :department, :expense_account, :income_account,
         :issue_product, :item_options_list, :klass, :location, :parent, :pricing_group, :purchase_tax_code,
         :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :store_display_image,
         :store_display_thumbnail, :store_item_template, :tax_schedule, :units_type, :expense_account


### PR DESCRIPTION
Why:

*Expense accounts were not being added to response for specific item types

This change addresses the need by:

*added the record reference expense account

Ticket

* [CLD-1157]