### PR TITLE
[CLD-1220-service-purchase-item-endpoint]

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -264,6 +264,7 @@ module NetSuite
     autoload :SalesOrderItemList,               'netsuite/records/sales_order_item_list'
     autoload :SalesRole,                        'netsuite/records/sales_role'
     autoload :SalesTaxItem,                     'netsuite/records/sales_tax_item'
+    autoload :ServicePurchaseItem,              'netsuite/records/service_purchase_item'
     autoload :ServiceResaleItem,                'netsuite/records/service_resale_item'
     autoload :ServiceSaleItem,                  'netsuite/records/service_sale_item'
     autoload :SerializedAssemblyItem,          'netsuite/records/serialized_assembly_item'

--- a/lib/netsuite/records/service_purchase_item.rb
+++ b/lib/netsuite/records/service_purchase_item.rb
@@ -1,0 +1,34 @@
+module NetSuite
+  module Records
+    class ServicePurchaseItem
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Support::Actions
+      include Namespaces::ListAcct
+
+      actions :get, :get_list, :add, :delete, :search, :upsert
+
+      fields :amortization_period, :available_to_partners, :cost, :cost_units, :created_date, :currency, :display_name, :generate_accrurals, :include_children, :is_fulfillable, :is_inactive, :is_taxable, :item_id, :last_modified_date, :manufacturing_charge_item, :purchase_description, :purchase_order_amount, :purchase_order_quantity, :purchase_order_quantity_diff, :receipt_amount, :receipt_quantity, :receipt_quantity_diff, :residual, :upc_code, :vendor_name
+
+      record_refs :klass, :cost_category, :custom_form, :department, :expense_account, :issue_product, :location, :parent, :purchase_tax_code, :sales_tax_code, :tax_schedule, :units_type
+
+      field :custom_field_list, CustomFieldList
+      field :subsidiary_list, RecordRefList
+
+
+      attr_reader   :internal_id
+      attr_accessor :external_id
+
+      def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+        initialize_from_attributes_hash(attributes)
+      end
+
+      def self.search_class_name
+        "Item"
+      end
+    end
+  end
+end

--- a/lib/netsuite/utilities.rb
+++ b/lib/netsuite/utilities.rb
@@ -169,6 +169,7 @@ module NetSuite
       ns_item ||= NetSuite::Utilities.get_record(NetSuite::Records::NonInventoryResaleItem, ns_item_internal_id, opts)
       ns_item ||= NetSuite::Utilities.get_record(NetSuite::Records::DiscountItem, ns_item_internal_id, opts)
       ns_item ||= NetSuite::Utilities.get_record(NetSuite::Records::OtherChargeSaleItem, ns_item_internal_id, opts)
+      ns_item ||= NetSuite::Utilities.get_record(NetSuite::Records::ServicePurchaseItem, ns_item_internal_id, opts)
       ns_item ||= NetSuite::Utilities.get_record(NetSuite::Records::ServiceSaleItem, ns_item_internal_id, opts)
       ns_item ||= NetSuite::Utilities.get_record(NetSuite::Records::GiftCertificateItem, ns_item_internal_id, opts)
       ns_item ||= NetSuite::Utilities.get_record(NetSuite::Records::KitItem, ns_item_internal_id, opts)


### PR DESCRIPTION
Why:

*Service Purchase Item support was not available in gem and endpoint is being used in a workflow that we are hoping to switch to the ruby connector

This change addresses the need by:

*Added service purchase item record support

Ticket

* [CLD-1220]