### PR TITLE
[CLD-1276-fix-typo]

### DIFF
--- a/lib/netsuite/actions/search.rb
+++ b/lib/netsuite/actions/search.rb
@@ -30,7 +30,6 @@ module NetSuite
               h
             end
           )
-
         NetSuite::Configuration
           .connection({ soap_header: preferences }, credentials)
           .call (@options.has_key?(:search_id)? :search_more_with_id : :search), :message => request_body

--- a/lib/netsuite/records/expense_report.rb
+++ b/lib/netsuite/records/expense_report.rb
@@ -9,7 +9,7 @@ module NetSuite
 
       actions :add, :get, :search, :update
 
-      fields :accounting_approval, :advance, :amount, :complete, :created_date, :due_date, :last_modified_date, :memo, :status, :supervisor_approval, :tax1_amt, :tax2_amt, :total, :tran_date, :train_id, :use_multi_currency
+      fields :accounting_approval, :advance, :amount, :complete, :created_date, :due_date, :last_modified_date, :memo, :status, :supervisor_approval, :tax1_amt, :tax2_amt, :total, :tran_date, :tran_id, :use_multi_currency
 
       # todo
       # field :accounting_book_detail_list,  AccountingBookDetailList


### PR DESCRIPTION
Why:

*There was a typo in the expense report record file that had tran_id as train_id making it so that variable could not be passed in or returned via the connector

This change addresses the need by:

*resolved the typo

Ticket

* [CLD-1276]