### PR TITLE
[L3-39-add-accounting_period_fields]

### DIFF
--- a/lib/netsuite/records/accounting_period.rb
+++ b/lib/netsuite/records/accounting_period.rb
@@ -8,7 +8,7 @@ module NetSuite
 
       actions :get, :get_list, :add, :delete, :upsert, :search
 
-      fields :allow_non_gl_changes, :end_date, :is_adjust, :is_quarter, :is_year, :period_name, :start_date
+      fields :allow_non_gl_changes, :end_date, :is_adjust, :is_quarter, :is_year, :period_name, :start_date, :all_locked, :ap_locked, :ar_locked, :closed, :closed_on_date, :payroll_locked
 
       record_refs :parent
 


### PR DESCRIPTION
Why:

*not all of the fields were being returned in payload for us to know when a period is locked.

This change addresses the need by:

*adding additional fields.

Ticket

[L3-39]