### PR TITLE
[L3-96] add_time_entry_support

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -284,6 +284,7 @@ module NetSuite
     autoload :Task,                             'netsuite/records/task'
     autoload :Term,                             'netsuite/records/term'
     autoload :TimeBill,                         'netsuite/records/time_bill'
+    autoload :TimeEntry,                        'netsuite/records/time_entry'
     autoload :TransactionBodyCustomField,       'netsuite/records/transaction_body_custom_field'
     autoload :TransactionColumnCustomField,     'netsuite/records/transaction_column_custom_field'
     autoload :TransactionShipGroup,             'netsuite/records/transaction_ship_group'

--- a/lib/netsuite/records/time_entry.rb
+++ b/lib/netsuite/records/time_entry.rb
@@ -1,0 +1,30 @@
+module NetSuite
+    module Records
+      class TimeEntry
+        include Support::Records
+        include Support::Fields
+        include Support::Actions
+        include Support::RecordRefs
+        include Namespaces::TranEmp
+  
+        actions :get, :get_list, :add, :update, :upsert, :upsert_list, :delete, :search
+  
+        fields :hours, :is_billable, :memo, :override_rate, :paid_externally, :rate, :status, :supervisor_approval, :time_type, :tran_date
+  
+        record_refs :case_task_event, :klass, :customer, :custom_form, :department, :employee, :item, :location, :payroll_item, :price, :subsidiary, :temporary_local_jurisdiction, :temporary_state_jurisdiction, :workplace
+  
+        field :custom_field_list, CustomFieldList
+  
+        attr_reader :internal_id
+        attr_accessor :external_id
+  
+        def initialize(attributes = {})
+          @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+          @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+          initialize_from_attributes_hash(attributes)
+        end
+  
+      end
+    end
+  end
+  

--- a/lib/netsuite/records/time_entry.rb
+++ b/lib/netsuite/records/time_entry.rb
@@ -1,30 +1,30 @@
 module NetSuite
-    module Records
-      class TimeEntry
-        include Support::Records
-        include Support::Fields
-        include Support::Actions
-        include Support::RecordRefs
-        include Namespaces::TranEmp
-  
-        actions :get, :get_list, :add, :update, :upsert, :upsert_list, :delete, :search
-  
-        fields :hours, :is_billable, :memo, :override_rate, :paid_externally, :rate, :status, :supervisor_approval, :time_type, :tran_date
-  
-        record_refs :case_task_event, :klass, :customer, :custom_form, :department, :employee, :item, :location, :payroll_item, :price, :subsidiary, :temporary_local_jurisdiction, :temporary_state_jurisdiction, :workplace
-  
-        field :custom_field_list, CustomFieldList
-  
-        attr_reader :internal_id
-        attr_accessor :external_id
-  
-        def initialize(attributes = {})
-          @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
-          @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
-          initialize_from_attributes_hash(attributes)
-        end
-  
+  module Records
+    class TimeEntry
+      include Support::Records
+      include Support::Fields
+      include Support::Actions
+      include Support::RecordRefs
+      include Namespaces::TranEmp
+
+      actions :get, :get_list, :add, :update, :upsert, :upsert_list, :delete, :search
+
+      fields :created_date, :last_modified_date, :is_billable, :memo, :override_rate, :paid_externally, :rate, :time_type
+
+      record_refs :approval_status, :billing_class, :case_task_event, :klass, :customer, :department, :item, :location, :payroll_item, :price, :subsidiary
+
+      field :custom_field_list, CustomFieldList
+      field :hours, Duration
+
+      attr_reader :internal_id
+      attr_accessor :external_id
+
+      def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+        initialize_from_attributes_hash(attributes)
       end
+
     end
   end
-  
+end


### PR DESCRIPTION
Why:

*Need to support Time Entry get/create/update for a customer.

This change addresses the need by:

*Added TimeEntry module in records.

Ticket

[L3-96]