### PR TITLE
return-netsuite-error-for-search-action-failures

### DIFF
--- a/lib/netsuite/actions/search.rb
+++ b/lib/netsuite/actions/search.rb
@@ -244,7 +244,7 @@ module NetSuite
             if response.success?
               NetSuite::Support::SearchResult.new(response, self, credentials)
             else
-              false
+              NetSuite::Error.new(response.body[:status][:status_detail])
             end
           end
         end


### PR DESCRIPTION
Why
currently, if the response is not successful, it just returns `false` but does not give any insight into what made it not successful.

Solution
Retrun a NetSuite::Error which will contain the error message