### PR TITLE
CD-712-have-inventory_detail-use-the-InventoryDetail-class-in-vendor-…

### DIFF
--- a/lib/netsuite/records/vendor_bill_item.rb
+++ b/lib/netsuite/records/vendor_bill_item.rb
@@ -7,13 +7,14 @@ module NetSuite
       include Namespaces::TranPurch
 
       fields  :amortization_end_date, :amortization_residual, :amortiz_start_date, :bin_numbers,  :bill_variance_status,
-              :description, :expiration_date, :gross_amt, :inventory_detail, :is_billable, :landed_cost, :line,
+              :description, :expiration_date, :gross_amt, :is_billable, :landed_cost, :line,
               :order_doc, :order_line, :quantity, :serial_numbers, :tax_rate_1, :tax_rate_2, :tax_1_amt, :vendor_name,
               :rate
 
       field :bill_receipts_list,  RecordRefList
       field :custom_field_list,   CustomFieldList
       field :options,             CustomFieldList
+      field :inventory_detail,    InventoryDetail
 
       read_only_fields :amount
 


### PR DESCRIPTION
…bill

Why
The `:inventory_detail` attribute should point to a spesific class `InventoryDetail`

Solution
Move `:inventory_detail` from `fields` to `field` and list the class name