### PR TITLE
return-error-object-for-get-failure

### DIFF
--- a/lib/netsuite/actions/get.rb
+++ b/lib/netsuite/actions/get.rb
@@ -82,7 +82,10 @@ module NetSuite
             if response.success?
              new(response.body)
             else
-              raise RecordNotFound, "#{self} with OPTIONS=#{options.inspect} could not be found, NetSuite message: #{response.errors.status_detail[:message]}"
+              NetSuite::Error.new(
+                code: response.errors.status_detail[:code],
+                message: response.errors.status_detail[:message]
+              )
             end
           end
 


### PR DESCRIPTION
return-error-object-for-get-failure

Why 
If the request to netsuite failed for any reason, it returned a 404 with a message that the record was not found by default even if it was an unrelated error.

Solution 
Return a Nesuite error object instead