### PR TITLE
add-item-record-type

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -203,6 +203,7 @@ module NetSuite
     autoload :ItemFulfillmentItemList,          'netsuite/records/item_fulfillment_item_list'
     autoload :ItemFulfillmentPackage,           'netsuite/records/item_fulfillment_package'
     autoload :ItemFulfillmentPackageList,       'netsuite/records/item_fulfillment_package_list'
+    autoload :Item,                             'netsuite/records/item'
     autoload :ItemGroup,                        'netsuite/records/item_group'
     autoload :ItemMember,                       'netsuite/records/item_member'
     autoload :ItemMemberList,                   'netsuite/records/item_member_list'

--- a/lib/netsuite/records/item.rb
+++ b/lib/netsuite/records/item.rb
@@ -1,0 +1,45 @@
+module NetSuite
+  module Records
+    class Item
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Support::Actions
+      include Namespaces::ListAcct
+
+      actions :search
+
+      fields :created_date,
+             :last_modified_date,
+             :purchase_description,
+             :expense_account,
+             :item_id,
+             :display_name,
+             :include_children,
+             :is_inactive,
+             :tax_schedule,
+             :deferral_account,
+             :is_fulfillable,
+             :generate_accruals,
+             :currency
+
+      field :custom_field_list,    CustomFieldList
+
+      attr_reader   :internal_id
+      attr_accessor :external_id
+
+      def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+        @xsi_type = attributes.delete(:"xsi:type") || attributes.delete(:"@xsi:type")
+        @item_type = determin_item_type(attributes) if @xsi_type
+        initialize_from_attributes_hash(attributes)
+      end
+
+      def determin_item_type(attributes)
+        @xsi_type.split(":").last
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Why
To give users access to the item record