### PR TITLE
fix-nme-Attributes-method

### DIFF
--- a/lib/netsuite/support/attributes.rb
+++ b/lib/netsuite/support/attributes.rb
@@ -14,7 +14,8 @@ module NetSuite
         attributes.select { |k,v| self.class.fields.include?(k) }.each do |k,v|
           send("#{k}=", v)
         end
-        self.klass = attributes[:class] if attributes[:class]
+
+        self.klass = attributes[:class] if attributes[:class] && self.respond_to?(:klass)
       end
 
     end


### PR DESCRIPTION
Why
Not all classes have or need a `klass` attribute