### PR TITLE
update-default-netsuite-api-version

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -101,7 +101,7 @@ module NetSuite
       if version
         self.api_version = version
       else
-        attributes[:api_version] ||= '2015_1'
+        attributes[:api_version] ||= '2016_2'
       end
     end
 


### PR DESCRIPTION
Why
version 2015 has been yanked. Updating the default to 2016_2